### PR TITLE
Add specific CommonJS documentation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ I still think the easiest way to learn React is [the official tutorial](https://
 
 ## Learning `npm`
 
-`npm` is the Node.js package manager and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` (Google it -- it’s important) and lets you install command-line tools written in JavaScript.
+`npm` is the Node.js package manager and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` ([read up on it](https://webpack.github.io/docs/commonjs.html) -- it’s important) and lets you install command-line tools written in JavaScript.
 
 Most reusable components, libraries and tools in the React ecosystem are available as `CommonJS` modules and are installed with `npm`.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ I still think the easiest way to learn React is [the official tutorial](https://
 
 ## Learning `npm`
 
-`npm` is the Node.js package manager and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` ([read up on it](https://webpack.github.io/docs/commonjs.html) -- it’s important) and lets you install command-line tools written in JavaScript.
+`npm` is the Node.js package manager and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` (read the [CommonJS Spec Wiki](http://wiki.commonjs.org/wiki/CommonJS) and/or the [Webpack CommonJS docs] (https://webpack.github.io/docs/commonjs.html) -- it’s important) and lets you install command-line tools written in JavaScript.
 
 Most reusable components, libraries and tools in the React ecosystem are available as `CommonJS` modules and are installed with `npm`.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ I still think the easiest way to learn React is [the official tutorial](https://
 
 ## Learning `npm`
 
-`npm` is the Node.js package manager and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` (read the [CommonJS Spec Wiki](http://wiki.commonjs.org/wiki/CommonJS) and/or the [Webpack CommonJS docs] (https://webpack.github.io/docs/commonjs.html) -- it’s important) and lets you install command-line tools written in JavaScript.
+`npm` is the Node.js package manager and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` and lets you install command-line tools written in JavaScript. Read [this post](http://0fps.net/2013/01/22/commonjs-why-and-how/) for background on why `CommonJS` is necessary for browsers, or the [CommonJS Spec Wiki](http://wiki.commonjs.org/wiki/Introduction) for more on the `CommonJS` API.
 
 Most reusable components, libraries and tools in the React ecosystem are available as `CommonJS` modules and are installed with `npm`.
 


### PR DESCRIPTION
I Googled for CommonJS and the top hit pertained to `require.js`, the second was Wikipedia, and anyone going to www.commonjs.org is going to hit a dead end pretty quickly.

I figured being a bit more specific wouldn't hurt.