### PR TITLE
Added link of React Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Additionally, there are a few topics that are often mentioned in the React commu
 
 It’s a common misconception that you need to waste a lot of time setting up tooling to start to learn React. In the official documentation you’ll find a [copy-paste HTML template](https://facebook.github.io/react/docs/getting-started.html#quick-start-without-npm) that you can save in an `.html` file and get started right away. **No tooling is required for this step, and don’t start learning extra tooling until you’re comfortable with React basics.**
 
-I still think the easiest way to learn React is [the official tutorial](https://facebook.github.io/react/docs/tutorial.html).
+I still think the easiest way to learn React is [the official tutorial](https://facebook.github.io/react/docs/tutorial.html) however if you want to have a structural guide to become a React Developer then do visit [React Developer Roadmap](https://roadmap.sh/react).
 
 ## Learning `npm`
 


### PR DESCRIPTION
Hi @petehunt,

I came across your repository [react-howto](https://github.com/petehunt/react-howto) and found it to be a valuable resource for React enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["React Developer Roadmap"](https://roadmap.sh/react). I took the initiative to submit a ["Pull Request"](https://github.com/petehunt/react-howto/pull/115) adding it in "Learning React itself" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz